### PR TITLE
Improve cross compilation support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,9 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    if cfg!(any(target_os = "macos", target_os = "ios")) {
+    // use the Cargo target to support cross compilation
+    let cargo_cfg_target = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if cargo_cfg_target == "macos" || cargo_cfg_target == "ios" {
         // The bindgen::Builder is the main entry point
         // to bindgen, and lets you build up options for
         // the resulting bindings.


### PR DESCRIPTION
When building a project using os_clock on OSX but with a command like `cargo build --target aarch64-unknown-linux-musl`, the build fails with error
```
  ./src/mach/mach_wrapper.h:1:10: fatal error: 'mach/mach_init.h' file not found
```
This is because the target for the build script is the local computer and not the one specified on the command line. This build script is used to generate bindings for Apple OSs, which we don't need when cross compiling. Instead, we can check the actual Cargo target.